### PR TITLE
Add Lightning5 Kangtai Cotech payload for rfx-lights-in

### DIFF
--- a/rfxcom.js
+++ b/rfxcom.js
@@ -448,6 +448,21 @@ module.exports = function (RED) {
                                 return;
                         }
                         break;
+
+                    case 17: // KANGTAI
+                        switch (evt.commandNumber) {
+                            case 0:
+                                msg.payload = "Off";
+                                break;
+
+                            case 1:
+                                msg.payload = "On";
+                                break;
+
+                            default:
+                                return;
+                        }
+                        break;
                 }
                 node.send(msg);
             }


### PR DESCRIPTION
I'm using node-red-contrib-rfxcom together with Home Assistant and the message that is created when I use one of my remotes with the KANGTAI subtype doesn't contain the command, making it impossible to update the switch in Home Assistant based on what the remote does. 

This PR adds the On and Off commands to the message payload following the same pattern the other subtypes use.

Thank you for this library, it neatly solves a bunch of my home automation cases using the RFXtrx433.