### PR TITLE
Fixed MCZ object format documentation

### DIFF
--- a/rfxcom.html
+++ b/rfxcom.html
@@ -1211,7 +1211,7 @@ The MCZ object format parameters are:
 </p>
 <table>
 <tr><td><b>fanSpeed</b></td><td>a single number applies to all fans, or an array. Values are 0 to 5, or 6 for 'auto'</td></tr>
-<tr><td><b>mode</b></td><td>"On", "Man", "Auto", or "Eco"</td></tr>
+<tr><td><b>mode</b></td><td>"Off", "Man", "Auto", or "Eco"</td></tr>
 <tr><td><b>beep</b></td><td>true or false</td></tr>
 <tr><td><b>flamePower</b></td><td>1 to 5</td></tr>
 </table>


### PR DESCRIPTION
The documentation was inaccurate. MCZ pellet stoves don't accept "on" as argument for mode. If you want a manual on, you must use "man". However, "off" was missing and is now added.